### PR TITLE
Gottlieb dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Ideally, every available service should be included in this project, but for any
   - Kafka zookeeper
 - **schema-registry** (core)
   - Kafka schema registry
+- **confluent control center** (core)
+  - Kafka UI, should be swapped out for open source version in future
 - **nginx** (core)
   - external web interface
 - **vouch-proxy**
@@ -75,3 +77,15 @@ SCHEMA_REGISTRY_URL="http://schema-registry:8081"
 Code running on local machine, not in docker-compose env
 BOOTSTRAP_SERVERS='localhost:19092'
 SCHEMA_REGISTRY_URL='http://localhost:8081'
+
+## Kafka UI
+
+You can view the Confluent Control Center at localhost:9021
+
+This interface is useful to view kafka topics, schemas, and messages.  This version is proprietary and will not be used in the final platform.  There are other open source options such as landoop topic ui and schema registry ui but I couldnt get those configured correctly so for now this works.
+
+## Data collection prototype components so far
+
+strain-producer - image contains sample gtsm bottle files, which it reads in and produces to topic 'gtsm_etl' based on the schema 'gtsm_etl.avsc'.  container exits when done reading files.
+
+ggkx-producer - container connects to RT-GNSS GGKX stream (NTRIP Castor) for station P225 and produces 1 sample per second messages containing an epoch of data.  Uses all_GNSS_position_metadata.avsc schema, and includes original ggkx data and also maps to unified 'position' schema.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,20 +67,105 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
-  # # RESTful proxy for kafka
-  # rest-proxy:
-  #   image: confluentinc/cp-kafka-rest:6.1.1
-  #   hostname: rest-proxy
-  #   depends_on:
-  #     - broker
-  #     - schema-registry
-  #   ports:
-  #     - 8082:8082
-  #   environment:
-  #     KAFKA_REST_HOST_NAME: rest-proxy
-  #     KAFKA_REST_BOOTSTRAP_SERVERS: 'broker:29092'
-  #     KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
-  #     KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://schema-registry:8081'
+  # Example producer for strainmeter bottle files.  contains 1 Day, Hour, and Min file, which it reads, parses, and produces to the kafka topic gtsm_etl
+  strain-producer:
+    image: unavdocker/strain_bottle_producer_prototype:latest
+    hostname: strain-producer
+    depends_on:
+      - broker
+      - schema-registry
+    environment:
+      BOOTSTRAP_SERVERS: "broker:9092"
+      SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+  
+    # Example producer for ggkx (gnss real time positions).  connects to station 
+  ggkx-producer:
+    image: unavdocker/ccp_ggkx_producer:latest
+    hostname: ggkx-producer
+    restart: unless-stopped
+    depends_on:
+      - broker
+      - schema-registry
+    environment:
+      BOOTSTRAP_SERVERS: "broker:9092"
+      SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+  
+  connect:
+    image: cnfldemos/cp-server-connect-datagen:0.5.0-6.2.0
+    hostname: connect
+    container_name: connect
+    depends_on:
+      - broker
+      - schema-registry
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: 'broker:29092'
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: compose-connect-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      # CLASSPATH required due to CC-2422
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-6.2.0.jar
+      CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
+      CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
+      CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:6.2.0
+    hostname: control-center
+    container_name: control-center
+    depends_on:
+      - broker
+      - schema-registry
+      - connect
+      - ksqldb-server
+    ports:
+      - "9021:9021"
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: 'broker:29092'
+      CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER: 'connect:8083'
+      CONTROL_CENTER_KSQL_KSQLDB1_URL: "http://ksqldb-server:8088"
+      CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL: "http://localhost:8088"
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONFLUENT_METRICS_TOPIC_REPLICATION: 1
+      PORT: 9021
+
+  ksqldb-server:
+    image: confluentinc/cp-ksqldb-server:6.2.0
+    hostname: ksqldb-server
+    container_name: ksqldb-server
+    depends_on:
+      - broker
+      - connect
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "broker:29092"
+      KSQL_HOST_NAME: ksqldb-server
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_CACHE_MAX_BYTES_BUFFERING: 0
+      KSQL_KSQL_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      KSQL_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
+      KSQL_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
+      KSQL_KSQL_CONNECT_URL: "http://connect:8083"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_REPLICATION_FACTOR: 1
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: 'true'
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: 'true'
 
   # Web front-end
   web:


### PR DESCRIPTION
Added kafka access from local machine environment
BOOTSTRAP_SERVERS='localhost:19092'
SCHEMA_REGISTRY_URL='http://localhost:8081'

Added Confluent Control Center for viewing kafka

Added strain2kafka and gnss2kafka 